### PR TITLE
Fix odd space above main content

### DIFF
--- a/web/themes/custom/swissartg/css/layout.css
+++ b/web/themes/custom/swissartg/css/layout.css
@@ -29,6 +29,7 @@
     "menu help"
     "menu content"
     "footer footer";
+    grid-template-rows: auto auto minmax(0, auto) auto auto;
   }
 }
 


### PR DESCRIPTION
Collapse the help content region when empty.